### PR TITLE
fix: re-add v-if for other fields

### DIFF
--- a/src/components/templates/EmailTemplate1.vue
+++ b/src/components/templates/EmailTemplate1.vue
@@ -75,7 +75,7 @@
                       :style="{fontSize: options.font.size + 'px'}"
                     >
                       <template v-for="item in otherFields">
-                        <tr :key="item.name">
+                        <tr v-if="item.value" :key="item.name">
                           <td>
                             <span
                               style="font-weight: 600;"


### PR DESCRIPTION
The check `v-if="item.value"` was removed in #11, which caused empty fields to be displayed.


### Before
![image](https://user-images.githubusercontent.com/13941027/50769251-4a663380-127b-11e9-9e23-022b21ab5d20.png)

### After
![image](https://user-images.githubusercontent.com/13941027/50769343-944f1980-127b-11e9-8c85-e3c185519f0b.png)


