### PR TITLE
fix: download link for firefox

### DIFF
--- a/src/views/Projects.vue
+++ b/src/views/Projects.vue
@@ -146,7 +146,13 @@ export default {
       const file = new Blob([data], { type: 'application/json' })
       a.href = URL.createObjectURL(file)
       a.download = project.name
-      a.click()
+      a.dispatchEvent(
+        new MouseEvent(`click`, {
+          bubbles: true,
+          cancelable: true,
+          view: window
+        })
+      )
       this.gaEventClick('download project')
     },
     onFileSelected (e) {


### PR DESCRIPTION
`a.click()` doesn't work in Firefox without first adding the node to the DOM.

This fires a click event instead.

See: https://stackoverflow.com/questions/32225904/programmatical-click-on-a-tag-not-working-in-firefox