### PR TITLE
fix: reset image object, not reset the values

### DIFF
--- a/src/store/modules/basic.js
+++ b/src/store/modules/basic.js
@@ -28,8 +28,10 @@ export default {
       state = Object.assign(state, data)
     },
     RESET_BASIC_FIELDS (state) {
-      state.image.link = ''
-      state.image.base64 = ''
+      state.image = {
+        base64: '',
+        link: ''
+      }
       state.fields = mainFields.basic
     }
   },


### PR DESCRIPTION
There is an issue when loading a project. If you click the load button twice, the image disappears. I think this is because `RESET_BASIC_FIELDS` is mutating the `image` object.

<details>
<summary>Click for current behviour</summary>
<img src="https://user-images.githubusercontent.com/13941027/50891382-0ba7b900-13f4-11e9-91fa-d33021250311.gif">
</details><br>

This resets the image state by creating a new object.

<details>
<summary>Click for new behviour</summary>
<img src="https://user-images.githubusercontent.com/13941027/50891473-3f82de80-13f4-11e9-9d35-43c5df055db7.gif">
</details><br><br>

